### PR TITLE
remove aliases prints on sub commands

### DIFF
--- a/command.go
+++ b/command.go
@@ -531,15 +531,7 @@ func (cmd *Command) ChildrenDescriptions(prefix, indent string) string {
 			continue
 		}
 
-		aliases := ""
-		if len(child.Aliases) > 0 {
-			aliasesBuff := bytes.NewBufferString("(aliases ")
-			aliasesBuff.WriteString(strings.Join(child.Aliases, ","))
-			aliasesBuff.WriteString(")")
-			aliases = aliasesBuff.String()
-		}
-
-		childStr := fmt.Sprintf(format, child.Name, child.Desc, aliases)
+		childStr := fmt.Sprintf(format, child.Name, child.Desc)
 		childrenList = append(childrenList, childStr)
 	}
 


### PR DESCRIPTION
remove the alias print in sub commands 
<img width="944" height="227" alt="image" src="https://github.com/user-attachments/assets/d14c2b5c-7450-4baa-aa75-bff21aa44f89" />
